### PR TITLE
Rewrite some ResQRobot javadoc with new style

### DIFF
--- a/src/io/github/thunderbots/resQ/ResQRobot.java
+++ b/src/io/github/thunderbots/resQ/ResQRobot.java
@@ -44,22 +44,22 @@ public class ResQRobot extends Robot {
 /*	private static final double BUCKET_TILT_INCREMENT = 0.02;*/
 	
 	/**
-	 * 
-	 * We find closed position by subtracting 1 by the other buckets closed position.
-	 * This sets up the positions of the boopers and buckets
-	 * 
+	 * Values representing the positions for each booper in the open and 
+	 * close positions. These were found by trial and error.
 	 */
-//	private static final double BLUE_BUCKET_DOOR_OPEN_POSITION = 0; 
-//	private static final double BLUE_BUCKET_DOOR_CLOSED_POSITION = .6;
+	private static final double LEFT_BOOPER_OPEN_POSITION = 1,
+			LEFT_BOOPER_CLOSED_POSITION = .45, 
+			RIGHT_BOOPER_OPEN_POSITION = 0, 
+			RIGHT_BOOPER_CLOSED_POSITION = .45;
 	
-	private static final double LEFT_BOOPER_OPEN_POSITION = 1;
-	private static final double LEFT_BOOPER_CLOSED_POSITION = .45;
-	
-//	private static final double RED_BUCKET_DOOR_OPEN_POSITION = 1; 
-//	private static final double RED_BUCKET_DOOR_CLOSED_POSITION = .4;
-	
-	private static final double RIGHT_BOOPER_OPEN_POSITION = 0;
-	private static final double RIGHT_BOOPER_CLOSED_POSITION = .45;
+//	/**
+//	 * Values represemting positions for the door servos in the open and
+//	 * close positions. These were found by trial and error.
+//	 */
+//	private static final double BLUE_BUCKET_DOOR_OPEN_POSITION = 0,
+//			BLUE_BUCKET_DOOR_CLOSED_POSITION = .6,
+//			RED_BUCKET_DOOR_OPEN_POSITION = 1,
+//			RED_BUCKET_DOOR_CLOSED_POSITION = .4;
 	
 	private static final double ENCODER_TICKS_PER_DRIVE_INCH = 131.25;
 	private static final double ENCODER_TICKS_PER_ROTATION_DEGREE = 131.25;


### PR DESCRIPTION
@Thunderbots5604/contributors

I put all the declarations on one line because the `private static final double` will propogate to all of the variables in the statement. The javadoc will also propogate to all the variables, which means that we only have to write the javadoc once, and it will be applied to all the variables. Before this change, the javadoc was written once, and only applied to the first of the 4 variables.
